### PR TITLE
fix (loadbalancer): update lb protocol change if service object modified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,6 @@ require (
 replace (
 	github.com/gophercloud/gophercloud => github.com/platform9/gophercloud v0.0.0-20230725192123-f5bf8afaa214
 	github.com/gophercloud/utils => github.com/platform9/gophercloud-utils v0.0.0-20230725192416-bb0e57cadb96
-	github.com/os-pc/gocloudlb => ../gocloudlb
+	github.com/os-pc/gocloudlb => github.com/rackspace-spot/gocloudlb v0.0.0-20250805033408-726ea5832e03
 	k8s.io/cloud-provider => github.com/platform9/k8s-cloud-provider v0.0.0-20230630054839-fab92f8cbf80
 )

--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,6 @@ require (
 replace (
 	github.com/gophercloud/gophercloud => github.com/platform9/gophercloud v0.0.0-20230725192123-f5bf8afaa214
 	github.com/gophercloud/utils => github.com/platform9/gophercloud-utils v0.0.0-20230725192416-bb0e57cadb96
-	github.com/os-pc/gocloudlb => github.com/rackspace-spot/gocloudlb v0.0.0-20250728140201-6d0e808d2620
+	github.com/os-pc/gocloudlb => ../gocloudlb
 	k8s.io/cloud-provider => github.com/platform9/k8s-cloud-provider v0.0.0-20230630054839-fab92f8cbf80
 )

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
-github.com/rackspace-spot/gocloudlb v0.0.0-20250728140201-6d0e808d2620 h1:6fTTyopqTF1gHLBkqMhkYGGiRJ3EdiSsBEZRPffOe2E=
-github.com/rackspace-spot/gocloudlb v0.0.0-20250728140201-6d0e808d2620/go.mod h1:vCN4JD8GTX/YkdqM3FVBtGBuHwJdC8ZRcJJHllq6qas=
+github.com/rackspace-spot/gocloudlb v0.0.0-20250805033408-726ea5832e03 h1:NIILQljs7JERnvUzLAT9gyLWmI0P/tHsB3WWVaXpSkw=
+github.com/rackspace-spot/gocloudlb v0.0.0-20250805033408-726ea5832e03/go.mod h1:vCN4JD8GTX/YkdqM3FVBtGBuHwJdC8ZRcJJHllq6qas=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=


### PR DESCRIPTION
This PR updates the service protocol to handle changes, specifically when the user switches between the client-IP protocol and the TCP protocol.

Will update the go.mod file once this PR is merged.

### Testing

Test setup:

Create a nginx server deployment and create LB service for that deployment. By modifying the below service yaml we can test various scenarios as mentioned.

```yaml
apiVersion: v1
kind: Service
metadata:
  name: nginx-client-ip
#  annotations:
#    loadbalancer.openstack.org/x-forwarded-for: "true"
spec:
  type: LoadBalancer
  selector:
    app: nginx-test
  ports:
    - name: http
      port: 8443
      targetPort: 80
#  loadBalancerSourceRanges:
#    - xxx.xxx.xxx.xxx/32
#    - xxx.xxx.xxx.xxx/32
```

1. Verify protocol switching between HTTP and TCP/UDP, and vice versa.  
2. Validate parameter integrity after service deletion.  
3. Confirm that changing port numbers triggers creation of new load balancers and removal of old ones.  
4. Test adding, modifying, and removing LoadBalancerSourceRanges configurations.  

UDP Testing

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: udp-echo
  labels:
    app: udp-echo
spec:
  containers:
  - name: udp-echo
    image: alpine
    command: ["sh", "-c", "apk add --no-cache socat && socat -v -T10 udp-recvfrom:12345,fork stdout"]
    ports:
    - containerPort: 12345
      protocol: UDP
---
apiVersion: v1
kind: Service
metadata:
  name: udp-lb
spec:
  type: LoadBalancer
  selector:
    app: udp-echo
  ports:
    - name: udp
      port: 12345
      targetPort: 12345
      protocol: UDP
```

```shell
# Send a UDP packet to your service's external IP/port
$ echo "hello" | nc -u <EXTERNAL-IP> 12345
```

```shell
$ k logs -f udp-echo                                                                                                                                                  130 ↵
fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz
(1/4) Installing ncurses-terminfo-base (6.5_p20250503-r0)
(2/4) Installing libncursesw (6.5_p20250503-r0)
(3/4) Installing readline (8.2.13-r1)
(4/4) Installing socat (1.8.0.3-r1)
Executing busybox-1.37.0-r18.trigger
OK: 9 MiB in 20 packages
2025/08/04 12:58:35 socat[9] W address is opened in read-write mode but only supports write-only
> 2025/08/04 12:58:35.000001670  length=6 from=0 to=5
hello
hello
2025/08/04 12:58:47 socat[10] W address is opened in read-write mode but only supports write-only
hello
> 2025/08/04 12:58:47.000067143  length=6 from=0 to=5
hello
```
Note: When updating the Loadbalancer protocol at first, I found that it's replacing the name with empty name which will lead to loadbalancer leak. The second commit in this PR will address this issues and fixed it.